### PR TITLE
[CLOUD-436] One namespace can contain only one EAP or JDG application

### DIFF
--- a/kube/src/main/java/org/openshift/ping/kube/Client.java
+++ b/kube/src/main/java/org/openshift/ping/kube/Client.java
@@ -79,7 +79,7 @@ public class Client {
         }
         url = url + "/" + op;
         if (labels != null && labels.length() > 0) {
-            url = url + "?labels=" + urlencode(labels);
+            url = url + "?labelSelector=" + urlencode(labels);
         }
         try (InputStream stream = openStream(url, headers, connectTimeout, readTimeout, operationAttempts, operationSleep, streamProvider)) {
             return ModelNode.fromJSONStream(stream);

--- a/kube/src/main/java/org/openshift/ping/kube/KubePing.java
+++ b/kube/src/main/java/org/openshift/ping/kube/KubePing.java
@@ -168,7 +168,7 @@ public class KubePing extends OpenshiftPing {
             String saToken = readFileToString(getSystemEnv(getSystemEnvName("SA_TOKEN_FILE"), saTokenFile, true));
             if (saToken != null) {
                 // curl -k -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-                // https://172.30.0.2:443/api/v1/namespaces/dward/pods?labels=application%3Deap-app
+                // https://172.30.0.2:443/api/v1/namespaces/dward/pods?labelSelector=application%3Deap-app
                 headers.put("Authorization", "Bearer " + saToken);
             }
             streamProvider = new InsecureStreamProvider();


### PR DESCRIPTION
[CLOUD-436] One namespace can contain only one EAP or JDG application
https://issues.jboss.org/browse/CLOUD-436
