### PR TITLE
CLOUD-651: Advance openshift-ping to 1.0.0.Final

### DIFF
--- a/activemq/pom.xml
+++ b/activemq/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/eap/build/pom.xml
+++ b/dist/eap/build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-dist-eap</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/eap/download/pom.xml
+++ b/dist/eap/download/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-dist-eap</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/eap/pom.xml
+++ b/dist/eap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-dist</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/wildfly/build/pom.xml
+++ b/dist/wildfly/build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-dist-wildfly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/wildfly/download/pom.xml
+++ b/dist/wildfly/download/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-dist-wildfly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/wildfly/pom.xml
+++ b/dist/wildfly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-dist</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dns/pom.xml
+++ b/dns/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/apps/basic-app-cache/pom.xml
+++ b/examples/apps/basic-app-cache/pom.xml
@@ -4,7 +4,7 @@
    <parent>
        <groupId>org.openshift.ping.examples</groupId>
        <artifactId>openshift-ping-examples-apps</artifactId>
-       <version>1.0.0-SNAPSHOT</version>
+       <version>1.0.0.Final</version>
        <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/examples/apps/basic-web-session/pom.xml
+++ b/examples/apps/basic-web-session/pom.xml
@@ -4,7 +4,7 @@
    <parent>
        <groupId>org.openshift.ping.examples</groupId>
        <artifactId>openshift-ping-examples-apps</artifactId>
-       <version>1.0.0-SNAPSHOT</version>
+       <version>1.0.0.Final</version>
        <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/examples/apps/hello-servlet/pom.xml
+++ b/examples/apps/hello-servlet/pom.xml
@@ -4,7 +4,7 @@
    <parent>
        <groupId>org.openshift.ping.examples</groupId>
        <artifactId>openshift-ping-examples-apps</artifactId>
-       <version>1.0.0-SNAPSHOT</version>
+       <version>1.0.0.Final</version>
        <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/examples/apps/pom.xml
+++ b/examples/apps/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/kube/pom.xml
+++ b/kube/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.openshift.ping</groupId>
     <artifactId>openshift-ping-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0.Final</version>
     <packaging>pom</packaging>
 
     <name>OpenShift PING - Parent</name>


### PR DESCRIPTION
CLOUD-651: Advance openshift-ping to 1.0.0.Final
https://issues.jboss.org/browse/CLOUD-651
