### PR TITLE
CLOUD-1520: Don't use proxy for all communications at all

### DIFF
--- a/activemq/src/main/java/org/openshift/activemq/discoveryagent/kube/InsecureStreamProvider.java
+++ b/activemq/src/main/java/org/openshift/activemq/discoveryagent/kube/InsecureStreamProvider.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.cert.CertificateException;
@@ -79,7 +80,7 @@ public class InsecureStreamProvider {
                     "%s opening connection: url [%s], headers [%s], connectTimeout [%s], readTimeout [%s]", getClass()
                             .getSimpleName(), url, headers, connectTimeout, readTimeout));
         }
-        URLConnection connection = new URL(url).openConnection();
+        URLConnection connection = new URL(url).openConnection(Proxy.NO_PROXY);
         if (headers != null) {
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 connection.addRequestProperty(entry.getKey(), entry.getValue());

--- a/common/src/main/java/org/openshift/ping/common/OpenshiftPing.java
+++ b/common/src/main/java/org/openshift/ping/common/OpenshiftPing.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
@@ -274,7 +275,7 @@ public abstract class OpenshiftPing extends PING {
             }
             HttpURLConnection connection = null;
             try {
-                connection = (HttpURLConnection) new URL(url).openConnection();
+                connection = (HttpURLConnection) new URL(url).openConnection(Proxy.NO_PROXY);
                 connection.addRequestProperty(Server.CLUSTER_NAME, clusterName);
                 if (_connectTimeout < 0 || _readTimeout < 0) {
                     throw new IllegalArgumentException(String.format(

--- a/common/src/main/java/org/openshift/ping/common/stream/BaseStreamProvider.java
+++ b/common/src/main/java/org/openshift/ping/common/stream/BaseStreamProvider.java
@@ -1,6 +1,7 @@
 package org.openshift.ping.common.stream;
 
 import java.io.IOException;
+import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Map;
@@ -14,7 +15,7 @@ public abstract class BaseStreamProvider implements StreamProvider {
         if (log.isLoggable(Level.FINE)) {
             log.log(Level.FINE, String.format("%s opening connection: url [%s], headers [%s], connectTimeout [%s], readTimeout [%s]", getClass().getSimpleName(), url, headers, connectTimeout, readTimeout));
         }
-        URLConnection connection = new URL(url).openConnection();
+        URLConnection connection = new URL(url).openConnection(Proxy.NO_PROXY);
         if (headers != null) {
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 connection.addRequestProperty(entry.getKey(), entry.getValue());

--- a/kube/src/test/java/org/openshift/ping/kube/test/ServerTestBase.java
+++ b/kube/src/test/java/org/openshift/ping/kube/test/ServerTestBase.java
@@ -21,6 +21,7 @@ import java.io.DataOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,7 +82,7 @@ public abstract class ServerTestBase extends TestBase {
         Message msg = new Message(null).setFlag(Message.Flag.DONT_BUNDLE)
                 .putHeader(pinger.getId(), hdr).setBuffer(streamableToBuffer(data));
         URL url = new URL("http://localhost:8888");
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
         conn.addRequestProperty(Server.CLUSTER_NAME, TestBase.CLUSTER_NAME);
         conn.setDoOutput(true);
         conn.setRequestMethod("POST");


### PR DESCRIPTION
Communications intra-pods don't need to be proxied. In fact
they must not. This patch prevents traffic being routed to
a proxy in case a java property like "http.proxyHost" is set
in the environment.

As a side effect of this change, clustering will not be
affected by env variables like "https_proxy".