### PR TITLE
[CLOUD-3163] Maven repositories must made https calls instead http and update vulnerable dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/eap/docker/jboss-eap-openshift.zip
 dist/wildfly/docker/wildfly-openshift.zip
 hs_err_pid*
 target/
+*.versionsBackup

--- a/dist/wildfly/build/pom.xml
+++ b/dist/wildfly/build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openshift.ping</groupId>
         <artifactId>openshift-ping-dist-wildfly</artifactId>
-        <version>1.2.0.Final</version>
+        <version>1.2.4.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/apps/basic-app-cache/pom.xml
+++ b/examples/apps/basic-app-cache/pom.xml
@@ -96,7 +96,7 @@
          <snapshots>
             <enabled>true</enabled>
          </snapshots>
-         <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+         <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       </repository>
    </repositories>
 

--- a/examples/apps/basic-web-session/pom.xml
+++ b/examples/apps/basic-web-session/pom.xml
@@ -90,7 +90,7 @@
          <snapshots>
             <enabled>true</enabled>
          </snapshots>
-         <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+         <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       </repository>
    </repositories>
 

--- a/examples/apps/hello-servlet/pom.xml
+++ b/examples/apps/hello-servlet/pom.xml
@@ -78,7 +78,7 @@
          <snapshots>
             <enabled>true</enabled>
          </snapshots>
-         <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+         <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       </repository>
    </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,11 @@
         <!-- Impl -->
         <version.oauth>20100527</version.oauth>
         <version.httpserver>1.0.4.Final</version.httpserver>
-        <version.undertow>1.1.0.Final</version.undertow>
+        <version.undertow>2.0.15.Final</version.undertow>
         <version.junit>4.11</version.junit>
         <!-- Build -->
         <version.org.apache.ant>1.8.2</version.org.apache.ant>
-        <version.org.apache.activemq>5.11.0</version.org.apache.activemq>
+        <version.org.apache.activemq>5.15.9</version.org.apache.activemq>
         <version.org.jboss.jandex>1.2.1.Final</version.org.jboss.jandex>
         <version.rhino.js>1.7R2</version.rhino.js>
     </properties>
@@ -231,7 +231,7 @@
         <repository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>
@@ -245,7 +245,7 @@
         <repository>
             <id>jboss-enterprise-repository-group</id>
             <name>JBoss Enterprise Technology Preview Repository Group</name>
-            <url>http://maven.repository.redhat.com/techpreview/all/</url>
+            <url>https://maven.repository.redhat.com/techpreview/all/</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>
@@ -262,7 +262,7 @@
         <pluginRepository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
See:https://issues.jboss.org/browse/CLOUD-3163

This PR intends to:

1. Update the `undertow-core` and `activemq-client` dependencies to their last versions due to CVEs (see JIRA)
2. Make https calls instead of http to maven repos
3. Bump the minor version of this project because of these corrections

All unit tests passing in JDK 8 and JDK 11. 

Signed-off-by: Ricardo Zanini <zanini@redhat.com>